### PR TITLE
Add help command

### DIFF
--- a/keyboards/menu.py
+++ b/keyboards/menu.py
@@ -1,0 +1,12 @@
+from aiogram.types import ReplyKeyboardMarkup
+from aiogram.utils.keyboard import ReplyKeyboardBuilder
+
+
+def get_main_menu() -> ReplyKeyboardMarkup:
+    """Return a keyboard with main bot commands."""
+    builder = ReplyKeyboardBuilder()
+    builder.button(text="/help")
+    builder.button(text="/guess")
+    builder.button(text="/cancel")
+    builder.adjust(2)
+    return builder.as_markup(resize_keyboard=True)

--- a/modules/chatbot/handlers.py
+++ b/modules/chatbot/handlers.py
@@ -2,11 +2,35 @@
 from aiogram import Router, types
 from aiogram.filters import Command  # filtro para comandos
 
+from keyboards.menu import get_main_menu
+
 router = Router()
 
-@router.message(Command(commands=["start", "help"]))
+@router.message(Command("start"))
 async def send_welcome(message: types.Message):
-    await message.answer(f"¡Hola, {message.from_user.first_name}! 👋 Bienvenido al bot.")
+    await message.answer(
+        f"¡Hola, {message.from_user.first_name}! 👋 Bienvenido al bot.",
+        reply_markup=get_main_menu(),
+    )
+
+
+@router.message(Command("help"))
+async def send_help(message: types.Message):
+    """Muestra información de ayuda sobre los comandos disponibles."""
+    text = (
+        "Comandos disponibles:\n"
+        "/start - Iniciar conversación con el bot\n"
+        "/help - Mostrar este mensaje de ayuda\n"
+        "/guess - Comenzar el juego de adivinar el número\n"
+        "/cancel - Cancelar el juego actual"
+    )
+    await message.answer(text)
+
+
+@router.message(Command("menu"))
+async def send_menu(message: types.Message):
+    """Muestra el menú principal del bot."""
+    await message.answer("Selecciona una opción:", reply_markup=get_main_menu())
 
 '''@router.message()
 async def echo(message: types.Message):


### PR DESCRIPTION
## Summary
- add a dedicated `/help` command that lists available commands
- show a reply keyboard menu on `/start` and `/menu`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686612351dac83319427944f423bd96c