### PR TITLE
Add Guess the Flag game

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from aiogram.enums import ParseMode
 from config import BOT_TOKEN
 from modules.chatbot.handlers import register_hello_handlers
 from modules.guess_position.handlers import router as guess_router
+from modules.guess_flag.handlers import router as flag_router
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ async def main():
 
     register_hello_handlers(dp)
     dp.include_router(guess_router)
+    dp.include_router(flag_router)
 
     logger.info("🤖 Bot iniciado y listo...")
     await dp.start_polling(bot)

--- a/config.py
+++ b/config.py
@@ -6,3 +6,11 @@ from dotenv import load_dotenv
 load_dotenv()
 
 BOT_TOKEN = os.getenv("TOKEN_TELEGRAM")
+
+# API de countries y configuración del juego de banderas
+COUNTRIES_API_URL = os.getenv(
+    "COUNTRIES_API_URL",
+    "https://restcountries.com/v3.1/all?fields=name,flags,translations",
+)
+
+FLAG_ATTEMPTS = int(os.getenv("FLAG_ATTEMPTS", "5"))

--- a/keyboards/menu.py
+++ b/keyboards/menu.py
@@ -7,6 +7,7 @@ def get_main_menu() -> ReplyKeyboardMarkup:
     builder = ReplyKeyboardBuilder()
     builder.button(text="/help")
     builder.button(text="/guess")
+    builder.button(text="/flag")
     builder.button(text="/cancel")
     builder.adjust(2)
     return builder.as_markup(resize_keyboard=True)

--- a/modules/chatbot/handlers.py
+++ b/modules/chatbot/handlers.py
@@ -22,6 +22,7 @@ async def send_help(message: types.Message):
         "/start - Iniciar conversación con el bot\n"
         "/help - Mostrar este mensaje de ayuda\n"
         "/guess - Comenzar el juego de adivinar el número\n"
+        "/flag - Comenzar el juego de adivinar la bandera\n"
         "/cancel - Cancelar el juego actual"
     )
     await message.answer(text)

--- a/modules/guess_flag/handlers.py
+++ b/modules/guess_flag/handlers.py
@@ -1,0 +1,73 @@
+from aiogram import Router, F
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+import asyncio
+
+from config import FLAG_ATTEMPTS
+from .services import get_random_country
+
+router = Router()
+
+class FlagGame(StatesGroup):
+    playing = State()
+
+@router.message(Command("flag"))
+async def cmd_flag(msg, state: FSMContext):
+    name, flag_url = await get_random_country()
+    await state.set_state(FlagGame.playing)
+    await state.update_data(
+        country=name,
+        flag=flag_url,
+        attempts=0,
+        history=[],
+        bot_msg_id=None,
+        chat_id=msg.chat.id,
+    )
+    sent = await msg.answer_photo(flag_url, caption="⚫️ Adivina la bandera. Usa /cancel para abortar.")
+    await state.update_data(bot_msg_id=sent.message_id)
+    await asyncio.sleep(1)
+    await msg.delete()
+
+@router.message(FlagGame.playing, F.text)
+async def process_guess(msg, state: FSMContext):
+    data = await state.get_data()
+    guess = msg.text.strip()
+    attempts = data["attempts"] + 1
+    history = data["history"] + [f"{guess} - {'✅' if guess.lower()==data['country'].lower() else '❌'}"]
+    await state.update_data(attempts=attempts, history=history)
+
+    caption = "\n".join(["⚫️ Adivina la bandera:", *history, f"Intentos: {attempts}/{FLAG_ATTEMPTS}.", "Usa /cancel para abortar."])
+    bot = msg.bot
+    await bot.edit_message_caption(chat_id=data["chat_id"], message_id=data["bot_msg_id"], caption=caption)
+    await asyncio.sleep(2)
+    await msg.delete()
+
+    win = guess.lower() == data["country"].lower()
+    if win or attempts >= FLAG_ATTEMPTS:
+        result = "🏆 ¡Correcto!" if win else f"❌ Fin del juego. Era {data['country']}"
+        final_caption = caption + "\n" + result
+        final_msg = await bot.edit_message_caption(chat_id=data["chat_id"], message_id=data["bot_msg_id"], caption=final_caption)
+        await asyncio.sleep(5)
+        await bot.delete_message(chat_id=data["chat_id"], message_id=final_msg.message_id)
+        await state.clear()
+
+@router.message(Command("cancel"), FlagGame.playing)
+async def cancel(msg, state: FSMContext):
+    data = await state.get_data()
+    bot = msg.bot
+    await bot.delete_message(chat_id=data["chat_id"], message_id=data["bot_msg_id"])
+    temp = await msg.answer("🔚 Juego cancelado.")
+    await asyncio.sleep(2)
+    await msg.delete()
+    await asyncio.sleep(5)
+    await temp.delete()
+    await state.clear()
+
+@router.message(FlagGame.playing)
+async def invalid(msg, state: FSMContext):
+    temp = await msg.answer("❗ Ingresa el nombre de un país.")
+    await asyncio.sleep(1)
+    await msg.delete()
+    await asyncio.sleep(2)
+    await temp.delete()

--- a/modules/guess_flag/services.py
+++ b/modules/guess_flag/services.py
@@ -1,0 +1,15 @@
+import random
+import aiohttp
+from config import COUNTRIES_API_URL
+
+async def get_random_country():
+    """Fetch list of countries and return random one's name and flag URL."""
+    async with aiohttp.ClientSession() as session:
+        async with session.get(COUNTRIES_API_URL) as resp:
+            data = await resp.json()
+    country = random.choice(data)
+    name = country.get("translations", {}).get("spa", {}).get("common")
+    if not name:
+        name = country.get("name", {}).get("common", "")
+    flag_url = country.get("flags", {}).get("png")
+    return name, flag_url


### PR DESCRIPTION
## Summary
- add new flag guessing game module
- wire new command into menu and help
- expose RESTCountries API URL and attempts in config
- include router in app startup

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686617746dec8331937ef7bb57bcefc0