### PR TITLE
Refactor bot init into core package

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,31 +1,9 @@
-# app.py
+"""Entry point to run the Telegram bot."""
+
 import asyncio
-import logging
-from aiogram import Bot, Dispatcher
-from aiogram.client.default import DefaultBotProperties
-from aiogram.enums import ParseMode
 
-from config import BOT_TOKEN
-from modules.chatbot.handlers import register_hello_handlers
-from modules.guess_position.handlers import router as guess_router
-from modules.guess_flag.handlers import router as flag_router
+from core.bot import run_polling
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
-
-async def main():
-    bot = Bot(
-        token=BOT_TOKEN,
-        default=DefaultBotProperties(parse_mode=ParseMode.HTML)
-    )
-    dp = Dispatcher()
-
-    register_hello_handlers(dp)
-    dp.include_router(guess_router)
-    dp.include_router(flag_router)
-
-    logger.info("🤖 Bot iniciado y listo...")
-    await dp.start_polling(bot)
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(run_polling())

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,4 @@
+"""Core package for bot initialization utilities."""
+
+from .bot import run_polling, create_bot, create_dispatcher  # noqa: F401
+

--- a/core/bot.py
+++ b/core/bot.py
@@ -1,0 +1,45 @@
+"""Utilities to create and run the Telegram bot."""
+
+import asyncio
+import logging
+
+from aiogram import Bot, Dispatcher
+from aiogram.client.default import DefaultBotProperties
+from aiogram.enums import ParseMode
+
+from config import BOT_TOKEN
+from modules.chatbot import router as chatbot_router
+from modules.guess_flag import router as flag_router
+from modules.guess_position import router as guess_router
+
+logger = logging.getLogger(__name__)
+
+
+def create_bot() -> Bot:
+    """Instantiate and return a configured :class:`Bot`."""
+    return Bot(
+        token=BOT_TOKEN,
+        default=DefaultBotProperties(parse_mode=ParseMode.HTML),
+    )
+
+
+def create_dispatcher() -> Dispatcher:
+    """Create dispatcher and register all routers."""
+    dp = Dispatcher()
+    dp.include_router(chatbot_router)
+    dp.include_router(guess_router)
+    dp.include_router(flag_router)
+    return dp
+
+
+async def run_polling() -> None:
+    """Start polling using created bot and dispatcher."""
+    bot = create_bot()
+    dp = create_dispatcher()
+    logger.info("🤖 Bot iniciado y listo...")
+    await dp.start_polling(bot)
+
+
+if __name__ == "__main__":
+    asyncio.run(run_polling())
+

--- a/modules/chatbot/__init__.py
+++ b/modules/chatbot/__init__.py
@@ -1,0 +1,5 @@
+"""Chatbot module exports its router."""
+
+from .handlers import router
+
+__all__ = ["router"]

--- a/modules/chatbot/handlers.py
+++ b/modules/chatbot/handlers.py
@@ -1,13 +1,15 @@
 # modules/chatbot/handlers.py
 from aiogram import Router, types
-from aiogram.filters import Command  # filtro para comandos
+from aiogram.filters import Command
 
 from keyboards.menu import get_main_menu
 
 router = Router()
 
+
 @router.message(Command("start"))
 async def send_welcome(message: types.Message):
+    """Send a welcome message and show the main menu."""
     await message.answer(
         f"¡Hola, {message.from_user.first_name}! 👋 Bienvenido al bot.",
         reply_markup=get_main_menu(),
@@ -16,7 +18,7 @@ async def send_welcome(message: types.Message):
 
 @router.message(Command("help"))
 async def send_help(message: types.Message):
-    """Muestra información de ayuda sobre los comandos disponibles."""
+    """Show help information about available commands."""
     text = (
         "Comandos disponibles:\n"
         "/start - Iniciar conversación con el bot\n"
@@ -30,12 +32,5 @@ async def send_help(message: types.Message):
 
 @router.message(Command("menu"))
 async def send_menu(message: types.Message):
-    """Muestra el menú principal del bot."""
+    """Display the bot main menu."""
     await message.answer("Selecciona una opción:", reply_markup=get_main_menu())
-
-'''@router.message()
-async def echo(message: types.Message):
-    await message.answer(f"Has dicho: {message.text}")''' #repite lo que el usuario dice
-
-def register_hello_handlers(dp):
-    dp.include_router(router)

--- a/modules/guess_flag/__init__.py
+++ b/modules/guess_flag/__init__.py
@@ -1,0 +1,5 @@
+"""Expose router for the guess_flag module."""
+
+from .handlers import router
+
+__all__ = ["router"]

--- a/modules/guess_position/__init__.py
+++ b/modules/guess_position/__init__.py
@@ -1,0 +1,7 @@
+"""Expose router for the guess_position module."""
+
+from .handlers import router
+
+__all__ = ["router"]
+
+


### PR DESCRIPTION
## Summary
- centralize bot and dispatcher setup inside `core.bot`
- expose routers from each module with `__init__`
- streamline `app.py` entry point
- clean up chatbot handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68661f84a6748331a603d575d48e95e9